### PR TITLE
Add do.preview option to help determine min.max.cluster.average

### DIFF
--- a/R/momentum_routines.R
+++ b/R/momentum_routines.R
@@ -557,13 +557,14 @@ filter.genes.by.cluster.expression <- function(emat,clusters,min.max.cluster.ave
   vi <- cl.emax>min.max.cluster.average;
 
   if (do.preview){
-    print(summary(quantile(cl.emax)))
-    plot(density(cl.emax), xlab='Max Cluster-Avg', main='')
+    msg <- paste0(length(which(vi)), '/', length(cl.emax), ' genes are selected')
+    plot(density(cl.emax), xlab='Max Cluster-Avg', main=msg)
     abline(v=quantile(cl.emax), col='blue', lty='dashed')
     abline(v=min.max.cluster.average, col='maroon', lty='dashed')
     axis(side=3, at=quantile(cl.emax), labels=round(quantile(cl.emax), 2),
          col.ticks='blue')
-    print(paste0(length(which(vi)), '/', length(cl.emax), ' genes are selected.'))
+    print(summary(cl.emax))
+    print(msg)
   }
 
   emat[vi,]

--- a/R/momentum_routines.R
+++ b/R/momentum_routines.R
@@ -91,11 +91,11 @@ gene.relative.velocity.estimates <- function(emat,nmat,deltaT=1,smat=NULL,steady
       cat("done\n")
     }
   }
-  
+
   emat.size <- Matrix::colSums(emat)/mult;
   emat.log.norm <- log(as.matrix(t(t(emat)/emat.size))+pcount);
   if(!is.null(old.fit)) { cellKNN <- old.fit[['cellKNN']]}
-  
+
   if(kCells>1) {
     if(is.null(cellKNN)) {
       cat("calculating cell knn ... ")
@@ -113,22 +113,22 @@ gene.relative.velocity.estimates <- function(emat,nmat,deltaT=1,smat=NULL,steady
     cat("calculating convolved matrices ... ")
     conv.emat <- emat %*% cellKNN[colnames(emat),colnames(emat)]
     conv.nmat <- nmat %*% cellKNN[colnames(nmat),colnames(nmat)]
-    cat("done\n")    
+    cat("done\n")
   } else {
     conv.emat <- emat; conv.nmat <- nmat; cellKNN <- NULL;
   }
-  
+
   # size estimates
   emat.cs <- Matrix::colSums(emat)/mult;
   nmat.cs <- Matrix::colSums(nmat)/mult;
-  
+
 
   conv.emat.cs <- Matrix::colSums(conv.emat)/mult;
   conv.nmat.cs <- Matrix::colSums(conv.nmat)/mult;
-  
 
-  
-  
+
+
+
   # size-normalized counts
   conv.emat.norm <- t(t(conv.emat)/conv.emat.cs)
   conv.nmat.norm <- t(t(conv.nmat)/conv.nmat.cs)
@@ -139,7 +139,7 @@ gene.relative.velocity.estimates <- function(emat,nmat,deltaT=1,smat=NULL,steady
 
   if(kGenes>1) {
     if(!is.null(old.fit) && !is.null(old.fit$geneKNN)) {
-      geneKNN <- old.fit$geneKNN; 
+      geneKNN <- old.fit$geneKNN;
     } else {
       cat("gene kNN ... ")
       geneKNN <- balancedKNN(t(log(as.matrix(conv.emat.norm)+pcount)),kGenes,kGenes*1.2e3,n.threads=n.cores); diag(geneKNN) <- 1;
@@ -154,12 +154,12 @@ gene.relative.velocity.estimates <- function(emat,nmat,deltaT=1,smat=NULL,steady
     cat("convolving matrices ... ")
     conv.emat.norm <- scaledGeneKNN %*% conv.emat.norm;
     conv.nmat.norm <- scaledGeneKNN %*% conv.nmat.norm;
-    
+
     cat("done\n")
   }
-  
+
   if(!is.null(smat)) {
-    
+
     if(kCells>1) {
       conv.smat <- smat %*% cellKNN[colnames(smat),colnames(smat)]
     } else {
@@ -170,8 +170,8 @@ gene.relative.velocity.estimates <- function(emat,nmat,deltaT=1,smat=NULL,steady
 
     if(kGenes>1) {
       conv.smat.norm <- scaledGeneKNN %*% conv.smat.norm;
-    } 
-    
+    }
+
     # use spanning reads to fit offset for the intronic reads, test correlation
     if(is.null(old.fit)) {
       cat("fitting smat-based offsets ... ")
@@ -182,7 +182,7 @@ gene.relative.velocity.estimates <- function(emat,nmat,deltaT=1,smat=NULL,steady
         return(c(o=pmax(0,as.numeric(sd$coef[1])),s=as.numeric(sd$coef[2]),r=r))
       },mc.cores=n.cores,mc.preschedule=T)))
       cat("done\n")
-      
+
     } else {
       sfit <- old.fit$sfit;
     }
@@ -210,7 +210,7 @@ gene.relative.velocity.estimates <- function(emat,nmat,deltaT=1,smat=NULL,steady
       o <- 0;
       df$o <- o;
       zi <- emat[gn,steady.state.cells]==0;
-      
+
       #table(zi)
       if(any(zi)) {
         do <- lm(n~e,data=df[zi,])
@@ -218,22 +218,22 @@ gene.relative.velocity.estimates <- function(emat,nmat,deltaT=1,smat=NULL,steady
         df$o <- max(0,do$coefficients[1])
       }
 
-      
+
     }
-    
-    
+
+
     #browser()
     d <- lm(n~e+offset(o)+0,data=df,weights=df$e^4+df$n^4);
     cell.col <- ac(rep(1,nrow(df)),alpha=0.1); names(cell.col) <- rownames(df)
-    if(!is.null(cell.colors)) { 
-      cc <- intersect(names(cell.colors),rownames(df)); 
+    if(!is.null(cell.colors)) {
+      cc <- intersect(names(cell.colors),rownames(df));
       cell.col[cc] <- cell.colors[cc]
     }
     plot(df$e,df$n,pch=21,bg=ac(cell.col,alpha=0.3),col=ac(1,alpha=0.1),cex=0.8,xlab='s',ylab='u',main=paste(gn,'fit'))
     if(!is.null(do)) {
       abline(do,lty=2,col=8)
     }
-    
+
     # min/max fit
     if(!is.null(fit.quantile)) {
       eq <- quantile(df$e,p=c(fit.quantile,1-fit.quantile))
@@ -244,9 +244,9 @@ gene.relative.velocity.estimates <- function(emat,nmat,deltaT=1,smat=NULL,steady
         d <- lm(n~e,data=df,weights=pw)
       }
     }
-    
-    
-    df <- df[order(df$e,decreasing=T),]; 
+
+
+    df <- df[order(df$e,decreasing=T),];
     lines(df$e,predict(d,newdata=df),lty=2,col=2)
 
     if(!is.null(cell.emb)) {
@@ -254,7 +254,7 @@ gene.relative.velocity.estimates <- function(emat,nmat,deltaT=1,smat=NULL,steady
     }
     if(kGenes>1) { return(invisible(geneKNN)) } else { return(1) }
   }
-  
+
   cat("fitting gamma coefficients ... ")
   if(is.null(old.fit)) {
     ko <- data.frame(do.call(rbind,parallel::mclapply(sn(rownames(conv.emat.norm)),function(gn) {
@@ -282,8 +282,8 @@ gene.relative.velocity.estimates <- function(emat,nmat,deltaT=1,smat=NULL,steady
           return(c(o=as.numeric(coef(d)[1]),g=as.numeric(coef(d)[2]),r=cor(df$e,df$n,method='spearman')))
         }
       }
-    
-        
+
+
     },mc.cores=n.cores,mc.preschedule=T)))
     ko <- na.omit(ko)
     cat("done. succesfful fit for",nrow(ko),"genes\n")
@@ -296,12 +296,12 @@ gene.relative.velocity.estimates <- function(emat,nmat,deltaT=1,smat=NULL,steady
     ko <- ko[vi,]
     if(!all(vi)) cat("filtered out",sum(!vi),"out of",length(vi),"genes due to low nmat-smat correlation\n")
   }
-  
+
   full.ko <- ko;
   vi <- ko$r>min.nmat.emat.correlation
   if(!all(vi)) cat("filtered out",sum(!vi),"out of",length(vi),"genes due to low nmat-emat correlation\n")
   ko <- ko[vi,]
-  
+
   vi <- ko$g>min.nmat.emat.slope
   if(!all(vi)) cat("filtered out",sum(!vi),"out of",length(vi),"genes due to low nmat-emat slope\n")
   ko <- ko[vi,]
@@ -314,31 +314,31 @@ gene.relative.velocity.estimates <- function(emat,nmat,deltaT=1,smat=NULL,steady
     npred[npred<0] <- 0;
     mval <- log2(conv.nmat.norm[names(gamma),]+pcount) - log2(npred+pcount);
     resl$mval <- mval;
-    
+
     #resl$conv.deltaE <- t.get.projected.delta(conv.emat.norm,conv.nmat.norm,gamma,offset=offset,delta=deltaT)
     #resl$conv.projected <- t.get.projected.cell2(conv.emat.norm,emat.size,as.matrix(resl$conv.deltaE),mult = mult,delta=deltaT2);
     #resl$conv.projected[resl$conv.projected<0] <- 0;
-    
+
     # switch back to non-gene-kNN conv.* matrices
     conv.emat.norm <- t(t(conv.emat)/conv.emat.cs)
     conv.nmat.norm <- t(t(conv.nmat)/conv.nmat.cs)
     # estimate gamma
     cat("re-estimating gamma of individual genes ... ")
-   
+
     am <- conv.nmat.norm[rownames(mval),]-offset; am[am<0] <- 0;
     fm <- log2(am) - mval - log2(conv.emat.norm[rownames(mval),])
     wm <- is.finite(fm)
     fm[!is.finite(fm)] <- 0;
     gammaA <- 2^(rowSums(fm * wm)/rowSums(wm))
     gammaA <- gammaA[is.finite(gammaA)];
- 
-    
+
+
     gamma <- gammaA;
     cat("done\n")
 
-    
+
     # can estimate deltaE from the mval
-    cat("calculating RNA velocity shift ... ")  
+    cat("calculating RNA velocity shift ... ")
     # estimate delta from M value
     deltaE <- t.get.projected.delta.from.log2ratio(em=conv.emat.norm,gamma=gamma,r=mval,delta=deltaT)
     #deltaE <- t.get.projected.delta2(conv.emat.norm,conv.nmat,conv.nmat.cs,gamma,offset=offset,delta=deltaT)
@@ -347,19 +347,19 @@ gene.relative.velocity.estimates <- function(emat,nmat,deltaT=1,smat=NULL,steady
   }
 
   resl$gamma <- gamma;
-    
+
   cat("done\n")
   cat("calculating extrapolated cell state ... ")
 
- 
+
   # reduced cell normalization (only genes for which momentum was estimated)
   emat.norm <- emat[rownames(emat) %in% rownames(deltaE),]
   emat.size <- Matrix::colSums(emat.norm)/mult;
   emat.norm <- t(t(emat.norm)/(emat.size));
-  
+
   emn <- t.get.projected.cell2(emat.norm,emat.size,as.matrix(deltaE),mult = mult,delta=deltaT2);
   #emn <- t.get.projected.cell(emat.norm,as.matrix(deltaE),target.mult = mult,model.mult=mult,delta=deltaT2,size.normalize=FALSE);
-  
+
   cat("done\n")
   full.ko$valid <- rownames(full.ko) %in% rownames(ko)
   resl <- c(resl,list(projected=emn,current=emat.norm,deltaE=deltaE,deltaT=deltaT,ko=full.ko,mult=mult,cellKNN=cellKNN,kCells=kCells));
@@ -372,7 +372,7 @@ gene.relative.velocity.estimates <- function(emat,nmat,deltaT=1,smat=NULL,steady
 ##'
 ##' @param emat - spliced (exonic) count matrix
 ##' @param nmat - unspliced (nascent) count matrix
-##' @param vel - initial gene-relative velocity estimates (output of the gene.relative.velocity.estimates function) 
+##' @param vel - initial gene-relative velocity estimates (output of the gene.relative.velocity.estimates function)
 ##' @param base.df gene structure information data frame ($base.df in output of read.smartseq2.bams), containing the following columns ($il - total intronic length in log10(length+1) scale; $el - total exonic length; $nex - number of expressed (above some low threshold) exons)
 ##' @param deltaT - amount of time to project the cell forward
 ##' @param smat - optional spanning read matrix (used in offset calculations)
@@ -400,28 +400,28 @@ gene.relative.velocity.estimates <- function(emat,nmat,deltaT=1,smat=NULL,steady
 ##'  #   For SMART-seq2, it is part of the \code{\link{read.smartseq2.bams}} output.
 ##'  #   For droplet data, this info can be obtained \code{\link{}}
 ##'  gvel <- global.velcoity.estimates(emat, nmat, rvel, dat$base.df, deltaT=1, kCells=5, kGenes = 15, kGenes.trim = 5, min.gene.cells = 0, min.gene.conuts = 500)
-##'  
+##'
 ##' }
 ##' @export
 global.velcoity.estimates <- function(emat,nmat,vel,base.df,deltaT=1,smat=NULL,kGenes=15,kGenes.trim=5,smooth.kGenes=0,kCells=10,deltaT2=1,min.gene.conuts=100,min.gene.cells=20,min.intron.length=10^3.5,min.exon.length=10^2.7,top.global.pearson.deviance=3,cellKNN=NULL,cell.dist=NULL,fit.quantile=NULL, m.pcount=5,n.cores=defaultNCores()) {
   mult <- vel$mult; # use the same library scale as in the supplied relative velocity estimates
   # reconsile gene lists
   gi <- intersect(intersect(rownames(base.df),rownames(emat)),rownames(nmat))
-  emat <- emat[gi,]; nmat <- nmat[gi,]; 
+  emat <- emat[gi,]; nmat <- nmat[gi,];
   base.df <- base.df[gi,]
 
   # do some gene filtering
   vi <- rowSums(emat[rownames(base.df),])>min.gene.conuts & rowSums(emat[rownames(base.df),]>0)>min.gene.cells
   if(!all(vi)) cat("filtered out",sum(!vi),"out of",length(vi),"genes due to low emat levels\n")
   base.df <- base.df[vi,]
-  
+
   vi <- base.df$il>log10(min.intron.length) & base.df$el>log10(min.exon.length) #requiring some minimum intronic and exonic lengths
   if(!all(vi)) cat("filtered out",sum(!vi),"out of",length(vi),"genes due to insufficient exonic or intronic lengths\n")
   base.df <- base.df[vi,]
 
   mult <- vel$mult;
-  
-  # do a quick global model of total nascent reads as a function of total exonic reads and gene structural parameters to filter 
+
+  # do a quick global model of total nascent reads as a function of total exonic reads and gene structural parameters to filter
   # out the genes with very high nascent/exonic ratio - those are likely driven by other transcripts
   df <- data.frame(e=rowSums(emat[rownames(base.df),]), n=rowSums(nmat[rownames(base.df),]), base.df)
   #df$ir <- expr.lstat[rownames(df),'t']/expr.lstat[rownames(df),'i']
@@ -430,19 +430,19 @@ global.velcoity.estimates <- function(emat,nmat,vel,base.df,deltaT=1,smat=NULL,k
   gm <- MASS::glm.nb(n~.,data=df,link=log,init.theta=2)
   vi <- resid(gm,type='pearson') <= top.global.pearson.deviance;
   if(!all(vi)) cat("filtered out",sum(!vi),"out of",length(vi),"genes due to excessive nascent counts\n")
-  base.df <- base.df[vi,] 
-  
+  base.df <- base.df[vi,]
+
   # reconcile gene lists and matrices
   gi <- intersect(rownames(base.df),rownames(emat))
-  emat <- emat[gi,]; nmat <- nmat[gi,]; 
+  emat <- emat[gi,]; nmat <- nmat[gi,];
   base.df <- base.df[gi,]
-  
+
   # start with gene-relative slopes
   gamma <- vel$gamma;
   gamma <- gamma[intersect(rownames(base.df),names(gamma))]
   #gamma <- ko$g; offset <- ko$o; names(gamma) <- names(offset) <- rownames(ko);
   cat("using relative slopes for",length(gamma),"genes to fit structure-based model ... ")
-  
+
   df <- data.frame(k=log(gamma),base.df[names(gamma),]); # note we're working with log gamma to get good resolution of low values
   df$eir <- log(((10^df$il)-1)/((10^df$el)-1)) # intronic/exonic ratio
   df$e <- log(rowSums(emat[rownames(df),])) # total gene expression
@@ -450,7 +450,7 @@ global.velcoity.estimates <- function(emat,nmat,vel,base.df,deltaT=1,smat=NULL,k
   # fit genome-wide model for the slope, based on the gene structural parameters and the total expression (exonic) magnitude
   km <- mgcv::gam(k~s(il,e)+s(eir)+s(nex),data=df,weights=sqrt(rowSums(emat[rownames(df),])))
   cat(paste0(round((1-km$deviance/km$null.deviance)*100,1),"% deviance explained.\n"))
-  
+
   # generate predictions for all genes
   df <- base.df; # note we're working with log gamma to get good resolution of low values
   df$eir <- log(((10^df$il)-1)/((10^df$el)-1)) # intronic/exonic ratio
@@ -458,7 +458,7 @@ global.velcoity.estimates <- function(emat,nmat,vel,base.df,deltaT=1,smat=NULL,k
   cat("predicting gamma ... ")
   sqGammaPred <- predict(km,newdata=df,type='response')
   cat("done\n")
-  
+
   # re-estimate offsets (and cellKNN) using relative fit
   cat("refitting offsets ... ")
   vel2 <- gene.relative.velocity.estimates(emat,nmat,smat=smat,kCells=kCells,kGenes=1,cell.dist=cell.dist,fit.quantile=fit.quantile)
@@ -471,11 +471,11 @@ global.velcoity.estimates <- function(emat,nmat,vel,base.df,deltaT=1,smat=NULL,k
     cat("calculating convolved matrices ... ")
     conv.emat <- emat %*% cellKNN[colnames(emat),colnames(emat)]
     conv.nmat <- nmat %*% cellKNN[colnames(nmat),colnames(nmat)]
-    cat("done\n")    
+    cat("done\n")
   } else {
     conv.emat <- emat; conv.nmat <- nmat;
   }
-  
+
   # size estimates
 
   conv.emat.cs <- Matrix::colSums(conv.emat)/mult;
@@ -483,9 +483,9 @@ global.velcoity.estimates <- function(emat,nmat,vel,base.df,deltaT=1,smat=NULL,k
   # size-normalized counts
   conv.emat.norm <- t(t(conv.emat)/conv.emat.cs)
   conv.nmat.norm <- t(t(conv.nmat)/conv.nmat.cs)
-  
 
-  
+
+
   # TODO: we want to restrict the set of genes that can be neighbors
   cat("calculating gene knn ... ")
   emm <- log10(as.matrix(conv.emat.norm)+1)
@@ -496,7 +496,7 @@ global.velcoity.estimates <- function(emat,nmat,vel,base.df,deltaT=1,smat=NULL,k
   npred <- t(t(conv.emat.norm[names(sqGammaPred),]*exp(as.numeric(sqGammaPred)))*conv.nmat.cs)
   # adjust for offset
   npred <- npred+ko$o
-  
+
   mval <- log2((conv.nmat[rownames(npred),]+m.pcount)/(npred+m.pcount))
   cat("adjusting mval offsets ... ")
   # estimate median M value (log2 observed nascent / expected nascent ratio) across kNN genes
@@ -505,13 +505,13 @@ global.velcoity.estimates <- function(emat,nmat,vel,base.df,deltaT=1,smat=NULL,k
     #x <- apply(mval[gin,],2,median) # works well too
     x <- apply(mval[gin,],2,mean,trim=kGenes.trim)
   },mc.cores=n.cores,mc.preschedule=TRUE))
-  
+
   if(kGenes>1) { # gene-convolved estimation
     # switch back to non-gene-kNN conv.* matrices
     conv.emat.norm <- t(t(conv.emat)/conv.emat.cs)
     conv.nmat.norm <- t(t(conv.nmat)/conv.nmat.cs)
   }
-  
+
   # adjust gamma predictions
   cat("re-estimating gamma ... ")
 
@@ -524,23 +524,23 @@ global.velcoity.estimates <- function(emat,nmat,vel,base.df,deltaT=1,smat=NULL,k
   gammaA <- gammaA[is.finite(gammaA)];
 
   #plot(log(old.gammaA),log(gammaA)); abline(a=0,b=1,lty=2,col=2);
-  
+
   cat("done\n")
-  
+
   # can estimate deltaE from the mval
-  cat("calculating RNA velocity shift ... ")  
+  cat("calculating RNA velocity shift ... ")
   deltaE <- t.get.projected.delta.from.log2ratio(em=conv.emat.norm,gamma=gammaA,r=mmval,delta=deltaT)
   cat("done\n")
   cat("calculating extrapolated cell state ... ")
   emat.size <- Matrix::colSums(emat)/mult;
-  
+
   em <- as.matrix(t(t(emat)/emat.size))
   em <- em[rownames(em) %in% rownames(deltaE),]
   emn <- t.get.projected.cell2(em,emat.size,as.matrix(deltaE),mult = mult,delta=deltaT2);
   cat("done\n")
   resl <- list(projected=emn,current=em,deltaE=deltaE,deltaT=deltaT,mval=mval,mult=mult,vel2=vel2,gammaA=gammaA);
   return(resl)
-  
+
 }
 
 ##' Filter genes by requirining minimum average expression within at least one of the provided cell clusters
@@ -563,8 +563,8 @@ filter.genes.by.cluster.expression <- function(emat,clusters,min.max.cluster.ave
 ##' @param vel velocity estimation (gene-relative or global)
 ##' @param nPcs number of successive PCs to visualize
 ##' @param cell.colors a named vector of cell colors for visualization
-##' @param scale 
-##' @param plot.cols 
+##' @param scale
+##' @param plot.cols
 ##' @param norm.nPcs optional total number of PCs to use for velocity magnitude normalization
 ##' @param do.par whether to set up graphical parameters of a plot
 ##' @param pc.multipliers an optional vector multipliers for the cell PC scores (useful for reorienting the PCs)
@@ -573,11 +573,11 @@ filter.genes.by.cluster.expression <- function(emat,clusters,min.max.cluster.ave
 ##' @param grid.sd standard deviation of the grid
 ##' @param grid.arrow.scale scale multiplier for the grid group velocity estimates
 ##' @param min.grid.cell.mass minimum cellular mass
-##' @param pcount 
-##' @param arrow.lwd 
-##' @param size.norm 
-##' @param ... 
-##' @return 
+##' @param pcount
+##' @param arrow.lwd
+##' @param size.norm
+##' @param ...
+##' @return
 ##' @export
 pca.velocity.plot <- function(vel,nPcs=4,cell.colors=NULL,scale='log',plot.cols=min(3,nPcs-1),norm.nPcs=NA,do.par=T, pc.multipliers=NULL, show.grid.flow=FALSE, grid.n=20, grid.sd=NULL, grid.arrow.scale=0.5, min.grid.cell.mass=1, pcount=1, arrow.lwd=1, size.norm=FALSE, ...) {
   x0 <- vel$current;
@@ -591,7 +591,7 @@ pca.velocity.plot <- function(vel,nPcs=4,cell.colors=NULL,scale='log',plot.cols=
     x1 <- t(t(x1/Matrix::colSums(x1)))*mean(sz);
   }
   # transform
-  if(scale=='log') { 
+  if(scale=='log') {
     cat("log ... ")
     x0.log <- log2(x0+pcount)
     x1.log <- log2(x1+pcount)
@@ -604,20 +604,20 @@ pca.velocity.plot <- function(vel,nPcs=4,cell.colors=NULL,scale='log',plot.cols=
     x0.log <- x0
     x1.log <- x1
   }
-  
+
   cat("pca ... ")
   cent <- rowMeans(x0.log);
   epc <- pcaMethods::pca(t(x0.log-cent),center=F,nPcs=ifelse(is.na(norm.nPcs),nPcs,norm.nPcs))
-  
+
   if(!is.null(pc.multipliers)) { # apply multipliers (used for flipping the direction of PCs in the plots)
     if(length(pc.multipliers)!=nPcs) stop("pc.multipliers must be a vector equal in length to the number of PCs")
     cat("pc multipliers ... ")
     epc@loadings <- t(t(epc@loadings)*pc.multipliers)
     epc@scores <- scale(epc@completeObs,scale=F,center=T) %*% epc@loadings;
   }
-  
+
   x1.scores <- t(x1.log - cent) %*% epc@loadings
-  
+
   # normalize velocities ...?
   cat("delta norm ... ")
   delta.pcs <- x1.scores-epc@scores
@@ -631,19 +631,19 @@ pca.velocity.plot <- function(vel,nPcs=4,cell.colors=NULL,scale='log',plot.cols=
     #ppos <- x1.scores[,c((i-1)+1,(i-1)+2)];
     ppos <- pos+delta.pcs[,c((i-1)+1,(i-1)+2)];
     plot(pos,bg=cell.colors[rownames(pos)],pch=21,col=adjustcolor(1,alpha=0.3),lwd=0.5,xlab=paste("PC",(i-1)+1),ylab=paste("PC",(i-1)+2),axes=T,main=paste('PC',(i-1)+1,' vs. PC',(i-1)+2,sep=''),  ...); box();
-    
+
     if(show.grid.flow) { # show grid summary of the arrows
       # arrow estimates for each cell
       ars <- data.frame(pos[,1],pos[,2],ppos[,1],ppos[,2])
       colnames(ars) <- c('x0','y0','x1','y1')
       arsd <- data.frame(xd=ars$x1-ars$x0,yd=ars$y1-ars$y0)
-      
+
       # set up a grid
       rx <- range(c(range(ars$x0),range(ars$x1)))
       ry <- range(c(range(ars$y0),range(ars$y1)))
       gx <- seq(rx[1],rx[2],length.out=grid.n)
       gy <- seq(ry[1],ry[2],length.out=grid.n)
-      
+
       # for each grid point calculate Gaussian-weighted delta average
       if(is.null(grid.sd)) {
         grid.sd <- sqrt((gx[2]-gx[1])^2 + (gy[2]-gy[1])^2)/2
@@ -658,7 +658,7 @@ pca.velocity.plot <- function(vel,nPcs=4,cell.colors=NULL,scale='log',plot.cols=
         cws <- pmax(1,Matrix::colSums(cw));
         gxd <- Matrix::colSums(cw*arsd$xd)/cws*grid.arrow.scale;
         gyd <- Matrix::colSums(cw*arsd$yd)/cws*grid.arrow.scale;
-        
+
         vg <- gw>=min.grid.cell.mass
         if(any(vg)) {
           suppressWarnings(arrows(rep(x,sum(vg)),gy[vg],x+gxd[vg],gy[vg]+gyd[vg],length=0.05,lwd=arrow.lwd))
@@ -676,37 +676,37 @@ pca.velocity.plot <- function(vel,nPcs=4,cell.colors=NULL,scale='log',plot.cols=
 }
 ##' Joint t-SNE visualization of the velocities
 ##'
-##' @param vel 
-##' @param cell.colors 
-##' @param scale 
-##' @param plot.cols 
-##' @param do.par 
-##' @param delta.norm 
-##' @param nPcs 
-##' @param norm.nPcs 
-##' @param perplexity 
-##' @param show.grid.flow 
-##' @param grid.n 
-##' @param grid.sd 
-##' @param min.grid.cell.mass 
-##' @param pcount 
-##' @param verbose 
-##' @param min.arrow.median.ratio 
-##' @param max.arrow.quantile 
-##' @param arrow.scale 
-##' @param arrow.lwd 
-##' @param xlab 
-##' @param ylab 
-##' @param n.cores 
-##' @param size.norm 
-##' @param ... 
-##' @return 
+##' @param vel
+##' @param cell.colors
+##' @param scale
+##' @param plot.cols
+##' @param do.par
+##' @param delta.norm
+##' @param nPcs
+##' @param norm.nPcs
+##' @param perplexity
+##' @param show.grid.flow
+##' @param grid.n
+##' @param grid.sd
+##' @param min.grid.cell.mass
+##' @param pcount
+##' @param verbose
+##' @param min.arrow.median.ratio
+##' @param max.arrow.quantile
+##' @param arrow.scale
+##' @param arrow.lwd
+##' @param xlab
+##' @param ylab
+##' @param n.cores
+##' @param size.norm
+##' @param ...
+##' @return
 ##' @export
 tSNE.velocity.plot <- function(vel,cell.colors=NULL,scale='log',plot.cols=3,do.par=T, delta.norm=TRUE, nPcs=15, norm.nPcs=nPcs*10, perplexity=ncol(vel$current)/3, show.grid.flow=FALSE, grid.n=20, grid.sd=NULL, min.grid.cell.mass=1, pcount=0.1, verbose=TRUE, min.arrow.median.ratio=1/10, max.arrow.quantile=0.9, arrow.scale=1, arrow.lwd=1, xlab="", ylab="", n.cores=defaultNCores(), size.norm=TRUE, ...) {
   x0 <- vel$current;
   x1 <- vel$projected;
   if(is.null(cell.colors)) { cell.colors <- adjustcolor(rep(1,ncol(x0)),alpha=0.3); names(cell.colors) <- colnames(x0) }
-  
+
   if(size.norm) {
     # rescale to the same size
     cat("rescaling ... ")
@@ -715,7 +715,7 @@ tSNE.velocity.plot <- function(vel,cell.colors=NULL,scale='log',plot.cols=3,do.p
     x1 <- t(t(x1)/Matrix::colSums(x1))*mean(sz);
   }
   # transform
-  if(scale=='log') { 
+  if(scale=='log') {
     cat("log ... ")
     x0.log <- log2(x0+pcount)
     x1.log <- log2(x1+pcount)
@@ -738,12 +738,12 @@ tSNE.velocity.plot <- function(vel,cell.colors=NULL,scale='log',plot.cols=3,do.p
       # normalize velocities ...?
       cat("delta norm ... ")
       delta.pcs <- x1.log-x0.log;
-      if(!is.na(norm.nPcs)){ 
+      if(!is.na(norm.nPcs)){
         delta.pcs <- delta.pcs/mean(sqrt(rowSums(delta.pcs^2))) # ? unsure about this (cell-wise L2 norm)
       }
       x1.log <- x0.log+delta.pcs;
     }
-    # drop extra Pcs 
+    # drop extra Pcs
     x0.log <- t(x0.log[,1:nPcs])
     x1.log <- t(x1.log[,1:nPcs])
   }
@@ -752,7 +752,7 @@ tSNE.velocity.plot <- function(vel,cell.colors=NULL,scale='log',plot.cols=3,do.p
   x0.emb <- emb[1:ncol(x0.log),]
   x1.emb <- emb[-(1:ncol(x0.log)),]
   rownames(x0.emb) <- rownames(x1.emb) <- colnames(x0.log);
-  
+
   cat("delta norm ... ") # again, somewhat unsure about this part
   delta.emb <- x1.emb - x0.emb;
   asize <- rowSums(delta.emb^2);
@@ -760,24 +760,24 @@ tSNE.velocity.plot <- function(vel,cell.colors=NULL,scale='log',plot.cols=3,do.p
   # restrict size top top 90% quantile
   delta.emb <- delta.emb/asize * pmin(asize,2*quantile(asize,p=max.arrow.quantile))*arrow.scale;
   delta.emb[no.arrow,] <- 0;
-  cat("done\n") 
+  cat("done\n")
   if(do.par) par(mfrow=c(1,1), mar = c(3.5,3.5,2.5,1.5), mgp = c(2,0.65,0), cex = 0.85);
   plot(x0.emb,bg=cell.colors[rownames(x0.emb)],pch=21,col=adjustcolor(1,alpha=0.3),xlab=ylab,ylab=xlab, ... ); box();
-  
-  
+
+
   if(show.grid.flow) { # show grid summary of the arrows
     # arrow estimates for each cell
     ars <- data.frame(x0.emb[,1],x0.emb[,2],x0.emb[,1]+delta.emb[,1],x0.emb[,2]+delta.emb[,2])
     colnames(ars) <- c('x0','y0','x1','y1')
     arsd <- data.frame(xd=ars$x1-ars$x0,yd=ars$y1-ars$y0)
-    
+
     # set up a grid
     cat("grid estimates ... ")
     rx <- range(c(range(ars$x0),range(ars$x1)))
     ry <- range(c(range(ars$y0),range(ars$y1)))
     gx <- seq(rx[1],rx[2],length.out=grid.n)
     gy <- seq(ry[1],ry[2],length.out=grid.n)
-    
+
     # for each grid point calculate Gaussian-weighted delta average
     if(is.null(grid.sd)) {
       grid.sd <- sqrt((gx[2]-gx[1])^2 + (gy[2]-gy[1])^2)/2
@@ -791,7 +791,7 @@ tSNE.velocity.plot <- function(vel,cell.colors=NULL,scale='log',plot.cols=3,do.p
       cws <- pmax(1,Matrix::colSums(cw));
       gxd <- Matrix::colSums(cw*arsd$xd)/cws
       gyd <- Matrix::colSums(cw*arsd$yd)/cws
-      
+
       vg <- gw>=min.grid.cell.mass
       if(any(vg)) {
         suppressWarnings(arrows(rep(x,sum(vg)),gy[vg],x+gxd[vg],gy[vg]+gyd[vg],length=0.05,lwd=arrow.lwd))
@@ -810,43 +810,43 @@ tSNE.velocity.plot <- function(vel,cell.colors=NULL,scale='log',plot.cols=3,do.p
 ##' Visualize RNA velocities on an existing embedding using correlation-based transition probability matrix within the kNN graph
 ##'
 ##' .. content for \details{} ..
-##' @title 
-##' @param emb 
-##' @param vel 
-##' @param n 
-##' @param cell.colors 
-##' @param corr.sigma 
-##' @param show.grid.flow 
-##' @param grid.n 
-##' @param grid.sd 
-##' @param min.grid.cell.mass 
-##' @param min.arrow.size 
-##' @param arrow.scale 
-##' @param max.grid.arrow.length 
-##' @param fixed.arrow.length 
-##' @param show.grid.points 
-##' @param scale 
-##' @param nPcs 
-##' @param arrow.lwd 
-##' @param xlab 
-##' @param ylab 
-##' @param n.cores 
-##' @param do.par 
-##' @param show.cell 
-##' @param cell.border.alpha 
-##' @param diffusion.steps 
-##' @param cc 
-##' @param ... 
-##' @return 
+##' @title
+##' @param emb
+##' @param vel
+##' @param n
+##' @param cell.colors
+##' @param corr.sigma
+##' @param show.grid.flow
+##' @param grid.n
+##' @param grid.sd
+##' @param min.grid.cell.mass
+##' @param min.arrow.size
+##' @param arrow.scale
+##' @param max.grid.arrow.length
+##' @param fixed.arrow.length
+##' @param show.grid.points
+##' @param scale
+##' @param nPcs
+##' @param arrow.lwd
+##' @param xlab
+##' @param ylab
+##' @param n.cores
+##' @param do.par
+##' @param show.cell
+##' @param cell.border.alpha
+##' @param diffusion.steps
+##' @param cc
+##' @param ...
+##' @return
 ##' @export
 show.velocity.on.embedding.cor <- function(emb,vel,n=5,cell.colors=NULL, corr.sigma=0.05, show.grid.flow=FALSE, grid.n=20, grid.sd=NULL, min.grid.cell.mass=1, min.arrow.size=NULL, arrow.scale=1, max.grid.arrow.length=NULL, fixed.arrow.length=FALSE, show.grid.points=FALSE, scale='log', nPcs=NA,  arrow.lwd=1, xlab="", ylab="", n.cores=defaultNCores(), do.par=T, show.cell=NULL, cell.border.alpha=0.3, diffusion.steps=10,cc=NULL, ...) {
   if(do.par) par(mfrow=c(1,1), mar = c(3.5,3.5,2.5,1.5), mgp = c(2,0.65,0), cex = 0.85);
   celcol <- 'white'
   if(is.null(show.cell)) { celcol <- cell.colors[rownames(emb)] }
   plot(emb,bg=celcol,pch=21,col=adjustcolor(1,alpha=cell.border.alpha), xlab=xlab, ylab=ylab, ...);
-  
+
   #plot(emb,bg=cell.colors[rownames(emb)],pch=21,col=adjustcolor(1,alpha=0.3), xlab=xlab, ylab=ylab);
-  em <- as.matrix(vel$current); 
+  em <- as.matrix(vel$current);
   ccells <- intersect(rownames(emb),colnames(em));
   em <- em[,ccells]; emb <- emb[ccells,]
   nd <- as.matrix(vel$deltaE[,ccells])
@@ -854,11 +854,11 @@ show.velocity.on.embedding.cor <- function(emb,vel,n=5,cell.colors=NULL, corr.si
   nd <- nd[cgenes,]; em <- em[cgenes,]
   #vg <- rownames(em) %in% rownames(r)
 
-  
+
   if(is.null(cc)) {
     # cosine projections
     cat("delta projections ... ")
-    
+
     if(scale=='log') {
       cat("log ")
       cc <- colDeltaCorLog10(em,(log10(abs(nd)+1)*sign(nd)),nthreads=n.cores);
@@ -896,7 +896,7 @@ show.velocity.on.embedding.cor <- function(emb,vel,n=5,cell.colors=NULL, corr.si
     points(emb[show.cell,1],emb[show.cell,2],pch=3,cex=1,col=1)
     di <- t(t(emb)-emb[i,])
     di <- di/sqrt(Matrix::rowSums(di^2))*arrow.scale; di[i,] <- 0;
-    dir <- Matrix::colSums(di*tp[,i]) 
+    dir <- Matrix::colSums(di*tp[,i])
     dic <- Matrix::colSums(di*(tp[,i]>0)/sum(tp[,i]>0)); # relative to expected kNN center
     dia <- dir-dic;
     suppressWarnings(arrows(emb[colnames(em)[i],1],emb[colnames(em)[i],2],emb[colnames(em)[i],1]+dic[1],emb[colnames(em)[i],2]+dic[2],length=0.05,lwd=1,col='blue'))
@@ -905,20 +905,20 @@ show.velocity.on.embedding.cor <- function(emb,vel,n=5,cell.colors=NULL, corr.si
     suppressWarnings(arrows(emb[colnames(em)[i],1],emb[colnames(em)[i],2],emb[colnames(em)[i],1]+dia[1],emb[colnames(em)[i],2]+dia[2],length=0.05,lwd=1,col='black'))
   } else if(show.grid.flow) { # show grid summary of the arrows
     # arrow estimates for each cell
-    
+
     cat("calculating arrows ... ")
     arsd <- data.frame(t(embArrows(emb,as.matrix(tp),arrow.scale,n.cores)))
     ars <- data.frame(cbind(emb,emb+arsd));
     colnames(ars) <- c('x0','y0','x1','y1')
     colnames(arsd) <- c('xd','yd')
-    
+
     # set up a grid
     cat("grid estimates ... ")
     rx <- range(c(range(ars$x0),range(ars$x1)))
     ry <- range(c(range(ars$y0),range(ars$y1)))
     gx <- seq(rx[1],rx[2],length.out=grid.n)
     gy <- seq(ry[1],ry[2],length.out=grid.n)
-    
+
     # for each grid point calculate Gaussian-weighted delta average
     if(is.null(grid.sd)) {
       grid.sd <- sqrt((gx[2]-gx[1])^2 + (gy[2]-gy[1])^2)/2
@@ -932,7 +932,7 @@ show.velocity.on.embedding.cor <- function(emb,vel,n=5,cell.colors=NULL, corr.si
       max.grid.arrow.length <- sqrt(sum((par('pin')/c(length(gx),length(gy)))^2))*0.25
       cat("max.grid.arrow.length=",max.grid.arrow.length," ")
     }
-    
+
     ginfo <- lapply(gx,function(x) {
       # cell distances (rows-cells,columsn - grid points)
       cd <- sqrt(outer(emb[,2],-gy,'+')^2 + (x-emb[,1])^2)
@@ -942,11 +942,11 @@ show.velocity.on.embedding.cor <- function(emb,vel,n=5,cell.colors=NULL, corr.si
       cws <- pmax(1,Matrix::colSums(cw));
       gxd <- Matrix::colSums(cw*arsd$xd)/cws
       gyd <- Matrix::colSums(cw*arsd$yd)/cws
-      
+
       al <- sqrt(gxd^2+gyd^2);
       vg <- gw>=min.grid.cell.mass & al>=min.arrow.size
-      
-      
+
+
       if(any(vg)) {
         #Arrows(rep(x,sum(vg)),gy[vg],x+gxd[vg],gy[vg]+gyd[vg],arr.length=pmin(0.2,ali[vg])*2.54,arr.type='curved')
         if(fixed.arrow.length) {
@@ -955,7 +955,7 @@ show.velocity.on.embedding.cor <- function(emb,vel,n=5,cell.colors=NULL, corr.si
           alen <- pmin(max.grid.arrow.length,sqrt( (gxd * par('pin')[1] / diff(par('usr')[c(1,2)]) )^2 + (gyd*par('pin')[2] / diff(par('usr')[c(3,4)]) )^2))
           lapply(which(vg),function(i) suppressWarnings(arrows(x,gy[i],x+gxd[i],gy[i]+gyd[i],length=alen[i],lwd=arrow.lwd)))
         }
-        
+
       }
       if(show.grid.points) points(rep(x,length(gy)),gy,pch='.',cex=1e-1,col=ac(1,alpha=0.4))
     })
@@ -967,7 +967,7 @@ show.velocity.on.embedding.cor <- function(emb,vel,n=5,cell.colors=NULL, corr.si
       di <- t(t(emb)-emb[i,])
       di <- di/sqrt(Matrix::rowSums(di^2))*arrow.scale; di[i,] <- 0;
       di <- Matrix::colSums(di*tp[,i]) - Matrix::colSums(di*(tp[,i]>0)/sum(tp[,i]>0)); # relative to expected kNN center
-      
+
       if(fixed.arrow.length) {
         suppressWarnings(arrows(emb[colnames(em)[i],1],emb[colnames(em)[i],2],emb[colnames(em)[i],1]+di[1],emb[colnames(em)[i],2]+di[2],length=0.05,lwd=arrow.lwd))
       } else {
@@ -987,38 +987,38 @@ show.velocity.on.embedding.cor <- function(emb,vel,n=5,cell.colors=NULL, corr.si
 ##' The direction of the arrow is towards n closest neighbors. The magnitude of the arrow is determined by the cosine projection of the velocity on to the chosen direction
 ##' n=1 will only show arrows for cells that end up being projected closer to some other cell than to the original position
 ##' n=k (k>1) will show an average direction
-##' 
-##' @title 
-##' @param emb 
-##' @param vel 
-##' @param n 
-##' @param embedding.knn 
-##' @param cell.colors 
-##' @param sigma 
-##' @param beta 
-##' @param arrow.scale 
-##' @param scale 
-##' @param nPcs 
-##' @param arrow.lwd 
-##' @param xlab 
-##' @param ylab 
-##' @param control.for.neighborhood.density 
-##' @param ntop.trajectories 
-##' @param do.par 
-##' @param show.cell.arrows 
-##' @param show.cell.trajectories 
-##' @param show.trajectories 
-##' @param show.all.trajectories 
-##' @param show.cell.diffusion.posterior 
-##' @param show.grid.flow 
-##' @param diffusion.steps 
+##'
+##' @title
+##' @param emb
+##' @param vel
+##' @param n
+##' @param embedding.knn
+##' @param cell.colors
+##' @param sigma
+##' @param beta
+##' @param arrow.scale
+##' @param scale
+##' @param nPcs
+##' @param arrow.lwd
+##' @param xlab
+##' @param ylab
+##' @param control.for.neighborhood.density
+##' @param ntop.trajectories
+##' @param do.par
+##' @param show.cell.arrows
+##' @param show.cell.trajectories
+##' @param show.trajectories
+##' @param show.all.trajectories
+##' @param show.cell.diffusion.posterior
+##' @param show.grid.flow
+##' @param diffusion.steps
 ##' @param cell.dist - optional custom distance (must include all of the cells that are intersecting between emb and vel)
-##' @param trajectory.spline.shape 
-##' @param cell.color.alpha 
-##' @param n.cores 
-##' @param n.trajectory.clusters 
-##' @param ... 
-##' @return 
+##' @param trajectory.spline.shape
+##' @param cell.color.alpha
+##' @param n.cores
+##' @param n.trajectory.clusters
+##' @param ...
+##' @return
 ##' @export
 show.velocity.on.embedding.eu <- function(emb,vel,n=30,embedding.knn=TRUE,cell.colors=NULL, sigma=NA, beta=1, arrow.scale=1, scale='log', nPcs=NA, arrow.lwd=1, xlab="", ylab="", control.for.neighborhood.density=FALSE, ntop.trajectories=1, do.par=T, show.cell.arrows=NULL, show.cell.trajectories=NULL, show.trajectories=FALSE, show.all.trajectories=FALSE, show.cell.diffusion.posterior=NULL, show.grid.flow=FALSE, diffusion.steps=10, cell.dist=NULL, trajectory.spline.shape=1, cell.color.alpha=0.5, n.cores=defaultNCores(), n.trajectory.clusters=10, ...) {
   if(is.null(cell.colors)) { cell.colors <- adjustcolor(rep(1,ncol(em)),alpha=0.3); names(cell.colors) <- colnames(em) }
@@ -1026,19 +1026,19 @@ show.velocity.on.embedding.eu <- function(emb,vel,n=30,embedding.knn=TRUE,cell.c
   cc <- 'white'
   if(is.null(show.cell.arrows) && is.null(show.cell.diffusion.posterior)) { cc <- cell.colors[rownames(emb)] }
   plot(emb,bg=cc,pch=21,col=ac(1,alpha=cell.color.alpha), xlab=xlab, ylab=ylab, ...);
-  
+
   em <- vel$current; emn <- vel$projected;
   ccells <- intersect(rownames(emb),colnames(em));
   emn <- emn[,ccells]; em <- em[,ccells]; emb <- emb[ccells,]
-  
+
   if(scale=='log') {
     cat("log scale ... ")
-    em <- log10(em+1); emn <- log10(emn+1); 
+    em <- log10(em+1); emn <- log10(emn+1);
   } else if(scale=='sqrt') {
     cat("sqrt scale ... ")
     em <- sqrt(em); emn <- sqrt(emn);
   }
-  
+
   if(!is.na(nPcs)) { # run PCA reduction on the em
     cat("reducing to",nPcs,"PCs ... ")
     epc.center <- rowMeans(em);
@@ -1046,17 +1046,17 @@ show.velocity.on.embedding.eu <- function(emb,vel,n=30,embedding.knn=TRUE,cell.c
     em <- t(epc@scores)
     emn <- t(t(emn - epc.center) %*% epc@loadings)
   }
-  
+
   cat("distance ... ")
   cc <- colEuclid(as.matrix(em),as.matrix(emn))
   cc0 <- colEuclid(as.matrix(em),as.matrix(em))
   cd <- (cc0-cc); # reduction in the Euclidean distance
 
   if(n>nrow(cc)) { n <- nrow(cc) }
-  
+
   # pick reasonable sigma and beta if they weren't provided
   if(is.na(sigma) | is.na(beta)) { mcd <- mean(abs(cd)/cc) }
-  # TODO: adaptive methods for signal 
+  # TODO: adaptive methods for signal
   if(is.na(sigma)) { sigma <- mcd/10 }
   if(is.na(beta)) { beta <- mcd/20 }
   cat("sigma=",round(sigma,3)," beta=",round(beta,3)," transition probs ... ")
@@ -1066,8 +1066,8 @@ show.velocity.on.embedding.eu <- function(emb,vel,n=30,embedding.knn=TRUE,cell.c
   tp <- exp(- ((cc0*f)^2) / (2*sigma^2))
   np <- exp(- ((cc0)^2) / (2*sigma^2))
 
-  
-  
+
+
 
   if(n<nrow(emb)) {
     if(!is.null(cell.dist)) {
@@ -1097,7 +1097,7 @@ show.velocity.on.embedding.eu <- function(emb,vel,n=30,embedding.knn=TRUE,cell.c
     tp <- tp*cell.knn;
     np <- np*cell.knn;
   }
-  
+
   # estimate density of the neighborhood
   tp <- t(t(tp)/Matrix::colSums(tp))
   np <- t(t(np)/Matrix::colSums(np))
@@ -1105,18 +1105,18 @@ show.velocity.on.embedding.eu <- function(emb,vel,n=30,embedding.knn=TRUE,cell.c
   #tp.nd <- colSums(tp); np.nd <- colSums(np);
   #tp <- tp * np.nd;
 
-  if(control.for.neighborhood.density) { 
+  if(control.for.neighborhood.density) {
     np.f <- diag(np);
     tp <- tp*(np.f)
     np <- np*(np.f)
   }
 
-  #diag(tp) <- diag(np) <- 0;  
+  #diag(tp) <- diag(np) <- 0;
   # normalize
   tp <- t(t(tp)/Matrix::colSums(tp))
   np <- t(t(np)/Matrix::colSums(np))
 
-  
+
 
   ## if(diffusion.step.size>1) {
   ##   # bring transition probability to the specified power
@@ -1126,12 +1126,12 @@ show.velocity.on.embedding.eu <- function(emb,vel,n=30,embedding.knn=TRUE,cell.c
   ##   tp <- t(t(tp)/Matrix::colSums(tp))
   ##   np <- t(t(np)/Matrix::colSums(np))
   ## }
-  
+
   # normalize transition probabilities
   rownames(tp) <- colnames(tp) <- rownames(np) <- colnames(np) <- colnames(em);
   cat("done\n")
-  
-  
+
+
   if(!is.null(show.cell.diffusion.posterior)) {
     i <- match(show.cell.diffusion.posterior,rownames(emb));
     if(is.na(i)) stop(paste('specified cell',i,'is not in the embedding'))
@@ -1139,7 +1139,7 @@ show.velocity.on.embedding.eu <- function(emb,vel,n=30,embedding.knn=TRUE,cell.c
     cp <- Diagonal(ncol(tp)); # cell position probabilities
     rownames(cp) <- colnames(cp) <- rownames(tp);
     ttp <- t(tp);
-    
+
     # run diffusion steps to figure out end positions
     cat("simulating diffusion ... ")
     for(i in 1:diffusion.steps) {
@@ -1158,7 +1158,7 @@ show.velocity.on.embedding.eu <- function(emb,vel,n=30,embedding.knn=TRUE,cell.c
     points(emb[i,1],emb[i,2],pch=3,cex=1,col=1)
     di <- t(t(emb)-emb[i,])
     di <- di/sqrt(Matrix::rowSums(di^2))*arrow.scale; di[i,] <- 0;
-    dir <- Matrix::colSums(di*tp[,i]) 
+    dir <- Matrix::colSums(di*tp[,i])
     dic <- Matrix::colSums(di*np[,i]); # relative to the neighborhood
     dia <- dir-dic;
     suppressWarnings(arrows(emb[colnames(em)[i],1],emb[colnames(em)[i],2],emb[colnames(em)[i],1]+dic[1],emb[colnames(em)[i],2]+dic[2],length=0.05,lwd=1,col='blue'))
@@ -1168,11 +1168,11 @@ show.velocity.on.embedding.eu <- function(emb,vel,n=30,embedding.knn=TRUE,cell.c
   } else if(show.trajectories) { # show diffusion paths
     cp <- Diagonal(ncol(tp)); # cell position probabilities
     rownames(cp) <- colnames(cp) <- rownames(tp);
-  
+
     #cpt <- as.array(cp);
     cpl <- list(); cpl[[1]] <- cp;
     #cp <- as.matrix(cp); tp <- as.matrix(tp)
-    
+
     #ep <- as.array(emb)
     ttp <- t(tp);
 
@@ -1191,14 +1191,14 @@ show.velocity.on.embedding.eu <- function(emb,vel,n=30,embedding.knn=TRUE,cell.c
 
 
     #cpt <- abind(lapply(cpl,as.matrix),along=3)
-    
+
     # calculate probabilistic trajectories to the final ntop points
-    
+
     # rank final points by probability
     cpo <- t(apply(-cp,1,order))
 
     # graph-based walkback approach
-    
+
     # construct a walkback graph
     trp <- as(ttp,'dgTMatrix')
     cat("constructing path graph ... ")
@@ -1210,7 +1210,7 @@ show.velocity.on.embedding.eu <- function(emb,vel,n=30,embedding.knn=TRUE,cell.c
     x <- spMatrix(nrow(cp)*(diffusion.steps+1),nrow(cp)*(diffusion.steps+1),i=x[,1],j=x[,2],x=rep(1,nrow(x)))
     g <- igraph::graph.adjacency(x,mode='directed')
     rm(x); gc();
-    
+
     # find topn trajectories for each cell
     cat("tracing shortest trajectories ... ")
     sps <- parallel::mclapply(1:nrow(cp),function(celli) {
@@ -1238,11 +1238,11 @@ show.velocity.on.embedding.eu <- function(emb,vel,n=30,embedding.knn=TRUE,cell.c
     spuci <- do.call(cbind,lapply(sps,function(y) do.call(cbind,lapply(y,function(x) all.cells %in% x))))
     usps <- unlist(sps,recursive=F); # will be used in looking up median trajectories in plotting
 
-    
+
     spuci.dist <- as.matrix(dist(t(spuci),method = 'manhattan'))
     spuci.pam <- cluster::pam(spuci.dist,n.trajectory.clusters)
     cat("done.\n")
-    
+
     # bezier
     # determine common start/end points
     #plot(emb,bg='white',pch=21,col=ac(1,alpha=cell.color.alpha), xlab=xlab, ylab=ylab);
@@ -1264,14 +1264,14 @@ show.velocity.on.embedding.eu <- function(emb,vel,n=30,embedding.knn=TRUE,cell.c
 
     cp <- Diagonal(ncol(tp)); # cell position probabilities
     rownames(cp) <- colnames(cp) <- rownames(tp);
-    
+
     #cpt <- as.array(cp);
     cpl <- list(); cpl[[1]] <- cp;
     #cp <- as.matrix(cp); tp <- as.matrix(tp)
-    
+
     #ep <- as.array(emb)
     ttp <- t(tp);
-    
+
     # run diffusion steps to figure out end positions
     cat("simulating diffusion ... ")
     for(i in 1:diffusion.steps) {
@@ -1284,10 +1284,10 @@ show.velocity.on.embedding.eu <- function(emb,vel,n=30,embedding.knn=TRUE,cell.c
     cpo <- t(apply(-cp,1,order))
 
     # graph-based walkback approach
-    
+
     # construct a walkback graph
     trp <- as(ttp,'dgTMatrix')
-    
+
     cat("constructing path graph ... ")
     x <- do.call(rbind,lapply(1:(diffusion.steps+1),function(i) {
       cbind(i=trp@i+1 + (i-1)*nrow(cp), # current time step
@@ -1297,12 +1297,12 @@ show.velocity.on.embedding.eu <- function(emb,vel,n=30,embedding.knn=TRUE,cell.c
     x <- spMatrix(nrow(cp)*(diffusion.steps+1),nrow(cp)*(diffusion.steps+1),i=x[,1],j=x[,2],x=rep(1,nrow(x)))
     g <- igraph::graph.adjacency(x,mode='directed')
     rm(x); gc();
-    
+
     # find topn trajectories for each cell
     cat("tracing shortest trajectories ... ")
     top.desti <- order(cp[celli,],decreasing=TRUE)[1:ntop.trajectories]
-    
-    
+
+
     # calculate cell-specific weights
     cw <- unlist(lapply(cpl,function(d) as.numeric(trp@x*(d[celli,trp@i+1]))))
     cw <- cw[1:igraph::ecount(g)] # trim extra edges
@@ -1331,7 +1331,7 @@ show.velocity.on.embedding.eu <- function(emb,vel,n=30,embedding.knn=TRUE,cell.c
     cp <- Diagonal(ncol(tp)); # cell position probabilities row-from col-to
     rownames(cp) <- colnames(cp) <- rownames(tp);
     ep <- as.array(emb)
-    
+
     for(i in 1:diffusion.steps) {
       cp <- cp %*% t(tp);
       # expected position
@@ -1354,21 +1354,21 @@ show.velocity.on.embedding.eu <- function(emb,vel,n=30,embedding.knn=TRUE,cell.c
     })
   }
   return(invisible(tp))
-  
+
 }
 
 
 ##' Read in cell-specific bam files for SMART-seq2 measurement
 ##'
-##' @title 
+##' @title
 ##' @param bam.files list of bam files
 ##' @param annotation.file refFlat genome annotation file (use gtfToGenePred to generate refFlat file from gtf)
 ##' @param min.exon.count minimum number of reads (across all cells) for an exon to be considered expressed in the dataset
-##' @param n.cores 
-##' @return 
+##' @param n.cores
+##' @return
 ##' @export
 read.smartseq2.bams <- function(bam.files,annotation.file,min.exon.count=100,n.cores=defaultNCores()) {
-  # read in annotation 
+  # read in annotation
   # TODO: enable direct gtf read
   cat("reading gene annotation ... ")
   x <- read.delim(annotation.file,header=F,sep="\t",stringsAsFactors=F)
@@ -1377,8 +1377,8 @@ read.smartseq2.bams <- function(bam.files,annotation.file,min.exon.count=100,n.c
   genes$p3 <- genes$end; genes$p3[genes$strand=="-"] <- genes$start[genes$strand=="-"];
   genes$size <- genes$end - genes$start;
   cat("done (",nrow(genes),"genes)\n")
-  
-  
+
+
   # parse out exon information
   cat("parsing exon information ... ")
   exons <- do.call(rbind,lapply(1:nrow(x),function(i) {
@@ -1387,15 +1387,15 @@ read.smartseq2.bams <- function(bam.files,annotation.file,min.exon.count=100,n.c
   }))
   exons <- data.frame(gene=as.character(exons[,3]),start=as.numeric(exons[,1]),end=as.numeric(exons[,2]),stringsAsFactors=F)
   exons$chr <- genes$chr[match(exons$gene,genes$name)]
-  
+
   # eliminate duplicated exons? - points.within will count reads only once anyhow
   exons <- exons[!duplicated(paste(exons[,1],exons[,2],exons[,3])),]
-  
+
   # eliminate multiple variants - keep the largest ones
   genes <- genes[order(genes$size,decreasing=T),]
   genes <- genes[!duplicated(genes$name),]
   cat("done\n")
-  
+
   # read in expression data
   #  - ultimately we'll get three kinds of matrices here:
   #      1. exonic reads
@@ -1404,7 +1404,7 @@ read.smartseq2.bams <- function(bam.files,annotation.file,min.exon.count=100,n.c
   #  - we will also use bam files to count the number of expressed exons,
   #    to adjust the structural parameters of each gene. Though this is not
   #    as important for the intron-only models.
-  
+
   # read in all bam files
   cat("reading in",length(bam.files),"bam files ... ")
   # annotate individual reads
@@ -1418,17 +1418,17 @@ read.smartseq2.bams <- function(bam.files,annotation.file,min.exon.count=100,n.c
   cat("adjusting gene annotation based on expressed regions ... ")
   # count total number of reads per exon to get the ones that are expressed ...
   tl <- Matrix::colSums(do.call(rbind,parallel::mclapply(cdl,function(x) { ect <- table(c(x$exonstart,x$exonend)); fect <- rep(0,nrow(exons)); fect[as.integer(names(ect))] <- ect; fect; },mc.cores=n.cores,mc.preschedule=T)))
-  
+
   # calculate gene length statistics, based on the expressed exons
   expr.exons <- exons[tl>min.exon.count,]; # expressed exons - those showing >100 reads dataset-wide
   expr.lstat <- lengthstats2(1e8,genes=genes,exons=expr.exons); # intron/exon length statistics for genes, considering only expressed exons
-  
+
   # compile joint table
   df <- data.frame(il=log10(expr.lstat[,2]+1),el=log10(expr.lstat[,3]+1)); rownames(df) <- rownames(expr.lstat)
   df$nex <- as.integer(table(expr.exons$gene)[rownames(df)]);
   df$nex[is.na(df$nex)] <- 0
   cat("done\n")
-  
+
   # construct sparse input matrices
   # exonic counts
   emat <- do.call(cbind,lapply(edl,function(d) { (d[,'exon']) }));  emat[!is.finite(emat)] <- 0;  emat <- as(emat,'dgCMatrix')
@@ -1436,8 +1436,8 @@ read.smartseq2.bams <- function(bam.files,annotation.file,min.exon.count=100,n.c
   smat <- do.call(cbind,lapply(edl,function(d) { (d[,'span']) }));  smat[!is.finite(smat)] <- 0;  smat <- as(smat,'dgCMatrix')
   # intron-only counts
   iomat <- do.call(cbind,lapply(edl,function(d) { (d[,'introno']) }));  iomat[!is.finite(iomat)] <- 0;  iomat <- as(iomat,'dgCMatrix')
-  
-  
+
+
   return(list(emat=emat,iomat=iomat,smat=smat,base.df=df,exons=exons,genes=genes,expr.lstat=expr.lstat))
 }
 
@@ -1446,12 +1446,12 @@ read.smartseq2.bams <- function(bam.files,annotation.file,min.exon.count=100,n.c
 ##' @param bam.files list of bam files (one per cell)
 ##' @param annotation.file gene annotation refFlat file
 ##' @param min.exon.count minimum number of molecules (across all cells) for the exon to be considered expressed
-##' @param n.cores 
+##' @param n.cores
 ##' @param min.umi.reads minimum number of read required per UMI/gene combination to be counted (defaults to 1)
-##' @return 
+##' @return
 ##' @export
 read.strtc1.bams <- function(bam.files,annotation.file,min.exon.count=100,n.cores=defaultNCores(),min.umi.reads=1) {
-  # read in annotation 
+  # read in annotation
   # TODO: enable direct gtf read
   cat("reading gene annotation ... ")
   x <- read.delim(annotation.file,header=F,sep="\t",stringsAsFactors=F)
@@ -1460,8 +1460,8 @@ read.strtc1.bams <- function(bam.files,annotation.file,min.exon.count=100,n.core
   genes$p3 <- genes$end; genes$p3[genes$strand=="-"] <- genes$start[genes$strand=="-"];
   genes$size <- genes$end - genes$start;
   cat("done (",nrow(genes),"genes)\n")
-  
-  
+
+
   # parse out exon information
   cat("parsing exon information ... ")
   exons <- do.call(rbind,lapply(1:nrow(x),function(i) {
@@ -1470,15 +1470,15 @@ read.strtc1.bams <- function(bam.files,annotation.file,min.exon.count=100,n.core
   }))
   exons <- data.frame(gene=as.character(exons[,3]),start=as.numeric(exons[,1]),end=as.numeric(exons[,2]),stringsAsFactors=F)
   exons$chr <- genes$chr[match(exons$gene,genes$name)]
-  
+
   # eliminate duplicated exons? - points.within will count reads only once anyhow
   exons <- exons[!duplicated(paste(exons[,1],exons[,2],exons[,3])),]
-  
+
   # eliminate multiple variants - keep the largest ones
   genes <- genes[order(genes$size,decreasing=T),]
   genes <- genes[!duplicated(genes$name),]
   cat("done\n")
-  
+
   # read in expression data
   #  - ultimately we'll get three kinds of matrices here:
   #      1. exonic reads
@@ -1487,7 +1487,7 @@ read.strtc1.bams <- function(bam.files,annotation.file,min.exon.count=100,n.core
   #  - we will also use bam files to count the number of expressed exons,
   #    to adjust the structural parameters of each gene. Though this is not
   #    as important for the intron-only models.
-  
+
   # read in all bam files
   cat("reading in",length(bam.files),"bam files ... ")
   # annotate individual reads
@@ -1497,10 +1497,10 @@ read.strtc1.bams <- function(bam.files,annotation.file,min.exon.count=100,n.core
     z$umig <- paste(gsub(".*?_","",z$name),z$gene)
     z[match(names(which(table(z$umig)>=min.umi.reads)),z$umig),]
   }
-  
+
   cdl <- parallel::mclapply(bam.files,function(x) t.reduce.umi(t.annotate.bam.reads(x,genes=genes,exons=exons,margin=1,exon.margin=1,use.names=T)),mc.cores=n.cores)
-  
-  
+
+
   cat("done\n")
   # get count estimates per gene
   cat("estimating gene counts ... ")
@@ -1510,17 +1510,17 @@ read.strtc1.bams <- function(bam.files,annotation.file,min.exon.count=100,n.core
   cat("adjusting gene annotation based on expressed regions ... ")
   # count total number of reads per exon to get the ones that are expressed ...
   tl <- Matrix::colSums(do.call(rbind,parallel::mclapply(cdl,function(x) { ect <- table(c(x$exonstart,x$exonend)); fect <- rep(0,nrow(exons)); fect[as.integer(names(ect))] <- ect; fect; },mc.cores=n.cores,mc.preschedule=T)))
-  
+
   # calculate gene length statistics, based on the expressed exons
   expr.exons <- exons[tl>min.exon.count,]; # expressed exons - those showing >100 reads dataset-wide
   expr.lstat <- lengthstats2(1e8,genes=genes,exons=expr.exons); # intron/exon length statistics for genes, considering only expressed exons
-  
+
   # compile joint table
   df <- data.frame(il=log10(expr.lstat[,2]+1),el=log10(expr.lstat[,3]+1)); rownames(df) <- rownames(expr.lstat)
   df$nex <- as.integer(table(expr.exons$gene)[rownames(df)]);
   df$nex[is.na(df$nex)] <- 0
   cat("done\n")
-  
+
   # construct sparse input matrices
   # exonic counts
   emat <- do.call(cbind,lapply(edl,function(d) { (d[,'exon']) }));  emat[!is.finite(emat)] <- 0;  emat <- as(emat,'dgCMatrix')
@@ -1528,8 +1528,8 @@ read.strtc1.bams <- function(bam.files,annotation.file,min.exon.count=100,n.core
   smat <- do.call(cbind,lapply(edl,function(d) { (d[,'span']) }));  smat[!is.finite(smat)] <- 0;  smat <- as(smat,'dgCMatrix')
   # intron-only counts
   iomat <- do.call(cbind,lapply(edl,function(d) { (d[,'introno']) }));  iomat[!is.finite(iomat)] <- 0;  iomat <- as(iomat,'dgCMatrix')
-  
-  
+
+
   return(list(emat=emat,iomat=iomat,smat=smat,base.df=df,exons=exons,genes=genes,expr.lstat=expr.lstat))
 }
 
@@ -1543,7 +1543,7 @@ t.annotate.bam.reads <- function(fname, genes, exons, chrl=unique(genes$chr), te
     param <- Rsamtools::ScanBamParam(flag=Rsamtools::scanBamFlag(isDuplicate=FALSE,isSecondaryAlignment=FALSE))
   }
   z <- GenomicAlignments::readGAlignments(fname,param=param,use.names=use.names)
-  
+
   bam.data <- data.frame(chr=as.vector(GenomeInfoDb::seqnames(z)),start=BiocGenerics::start(z),end=BiocGenerics::end(z),strand=as.vector(BiocGenerics::strand(z)),stringsAsFactors=F)
   if(!is.null(tags)) {
     bam.data <- cbind(bam.data,as.data.frame(elementMetadata((z))))
@@ -1552,44 +1552,44 @@ t.annotate.bam.reads <- function(fname, genes, exons, chrl=unique(genes$chr), te
     bam.data$name <- names(z)
   }
   bam.data <- bam.data[bam.data$chr %in% chrl,]
-  
+
   chrl <- chrl[chrl %in% unique(bam.data$chr)]
-  
+
   ## assign reads to genes
   x <- do.call(rbind,lapply(chrl,function(chr) {
     ri <- which(bam.data$chr==chr)
     results <- data.frame(bam.data[ri,],gene=rep(NA,length(ri)), exonstart=0, exonend=0, readtype='NI',stringsAsFactors=F) ## intronic read unless evidence to change it
     gi <- which(genes$chr==chr)
     ei <- which(exons$chr==chr)
-    
+
     # check if the read is associated with any gene
     pi1 <- points.within(bam.data$start[ri],genes$start[gi]-margin,genes$end[gi]+margin); # note that many gene fragments are supplied at once - no need to loop in R!
     pi2 <- points.within(bam.data$end[ri],genes$start[gi]-margin,genes$end[gi]+margin);
     vi <- pi1>0 | pi2>0;
-    if(any(vi)) { 
+    if(any(vi)) {
       results$gene[vi] <- genes$name[gi[pmax(pi1[vi],pi2[vi])]]; # take largest matched gene index .. should check for consistency
     }
-    
+
     # check exon mapping
     pi1 <- points.within(bam.data$start[ri],exons$start[ei]-exon.margin,exons$end[ei]+exon.margin);
     pi2 <- points.within(bam.data$end[ri],exons$start[ei]-exon.margin,exons$end[ei]+exon.margin);
-    
+
     # see if both ends map to the same exon - that's NC
     vi <- pi1>0  & pi1==pi2
     if(any(vi)) { results$readtype[vi] <- 'NC'; results$gene[vi] <- exons$gene[ei[pi1[vi]]]; }
-    
+
     # different exons - NE
     vi <- pi1>0 & pi2>0 & pi1!=pi2
     if(any(vi)) { results$readtype[vi] <- 'NE'; results$gene[vi] <- exons$gene[ei[pi1[vi]]]; }
-    
+
     # one exon, and one something else - assume NS for now, will check for margins later
     vi <- sign(pi1) != sign(pi2);
     if(any(vi)) { results$readtype[vi] <- 'NS'; results$gene[vi] <- exons$gene[ei[pmax(pi1,pi2)[vi]]]; }
-    
+
     # note: I am not sure what these two values are needed for, but here's how to get them
     pi1[pi1==-1] <- NA; pi2[pi2==-1] <- NA;
     results$exonstart <- ei[pi1]; results$exonend <- ei[pi2];
-    
+
     # assign margin classes (N5 - fully in the 5' margin, N3 - fully in the 3', N5b - spanning exon and 5' margin, N3b - spanning exon and 3' margin)
     if(margin>0) {
       # start is in the start margin
@@ -1597,27 +1597,27 @@ t.annotate.bam.reads <- function(fname, genes, exons, chrl=unique(genes$chr), te
       pi1check <- points.within(bam.data$start[ri],genes$start[gi],genes$end[gi]); # check for genes
       ivi <- pi1>0 & pi1check>0 # both in margin and in some other gene - should be invalidated
       if(any(ivi)) { results$gene[ivi] <- NA }
-      
+
       # if it is in vi, then it must be partially margin (joining margin and the first/last exon), otherwise it's fully in margin
       vi2 <- pi1>0 & vi;
       if(any(vi2)) { results$readtype[vi2] <- ifelse(genes$strand[gi[pi1[vi2]]]=='+','N5b','N3b') }
       vi2 <- pi1>0 & !vi;
       if(any(vi2)) { results$readtype[vi2] <- ifelse(genes$strand[gi[pi1[vi2]]]=='+','N5','N3') }
-      
+
       # and now check the other end of the read
       # end is in the margin
       pi2 <- points.within(bam.data$end[ri],genes$end[gi]+1,genes$end[gi]+margin);
       pi2check <- points.within(bam.data$end[ri],genes$start[gi],genes$end[gi]); # check for genes
       ivi <- pi2>0 & pi2check>0 # both in margin and in some other gene - should be invalidated
       if(any(ivi)) { results$gene[ivi] <- NA }
-      
+
       # if it is in vi, then it must be partially margin (joining margin and the first/last exon), otherwise it's fully in margin
       vi2 <- pi2>0 & vi;
       if(any(vi2)) { results$readtype[vi2] <- ifelse(genes$strand[gi[pi2[vi2]]]=='+','N3b','N5b') }
       vi2 <- pi2>0 & !vi;
       if(any(vi2)) { results$readtype[vi2] <- ifelse(genes$strand[gi[pi2[vi2]]]=='+','N3','N5') }
     }
-    
+
     # omit reads that didn't get assinged to genes (or were invalidated)
     results <- results[!is.na(results$gene),]
     return(results)
@@ -1629,27 +1629,27 @@ t.get.estimates2 <- function(cd,genes) {
   cd$gene <- match(cd$gene,genes$name);
   # number of reads within the exons
   vi <- cd$readtype %in% c("NC","NE");  exon.counts <- tapply(cd$gene[vi],cd$gene[vi],length)
-  
+
   # intronic reads
   vi <- cd$readtype %in% c("NI","NS"); intron.counts <- tapply(cd$gene[vi],cd$gene[vi],length)
   # intron only counts
   vi <- cd$readtype %in% c("NI"); introno.counts <- tapply(cd$gene[vi],cd$gene[vi],length)
   # span only counts
   vi <- cd$readtype %in% c("NS"); span.counts <- tapply(cd$gene[vi],cd$gene[vi],length)
-  
+
   # number of reads in the upstream region (don't include those briding exon, since they're supposed to be a different strand)
   vi <- cd$readtype %in% c("N5"); upstream.counts <- tapply(cd$gene[vi],cd$gene[vi],length)
   # downstream region (running from the exon is fine, since it can be the same strand)
   vi <- cd$readtype %in% c("N3","N3b"); downstream.counts <- tapply(cd$gene[vi],cd$gene[vi],length)
-  
-  
+
+
   # construct report matrix
   df <- matrix(NA,nrow=nrow(genes),ncol=7)
   df[as.integer(names(exon.counts)),1] <- exon.counts
   df[,2] <- 0
   # normalize by the expected fraction of reads from the last 1kb (assume that the last exon is ~1kb) TODO: transcript-coordinate estimation
   #df[,2] <- df[,2]/lstat.e3$e*lstat$e;
-  
+
   df[as.integer(names(intron.counts)),3] <- intron.counts
   df[as.integer(names(upstream.counts)),4] <- upstream.counts
   df[as.integer(names(downstream.counts)),5] <- downstream.counts
@@ -1686,7 +1686,7 @@ edgeR.libsize <- function(mat, ...) {
 sn <- function(x) { names(x) <- x; x}
 
 # adjust colors, while keeping the vector names
-#' 
+#'
 #' @param color
 #' @param ... parameters passsed to adjustcolor
 #' @export
@@ -1706,7 +1706,7 @@ val2col <- function(x,gradientPalette=NULL,zlim=NULL,gradient.range.quantile=0.9
     }
     x[x<zlim[1]] <- zlim[1]; x[x>zlim[2]] <- zlim[2];
     x <- (x-zlim[1])/(zlim[2]-zlim[1])
-    
+
   } else {
     if(is.null(gradientPalette)) {
       gradientPalette <- colorRampPalette(c("blue", "grey90", "red"), space = "Lab")(1024)
@@ -1719,9 +1719,9 @@ val2col <- function(x,gradientPalette=NULL,zlim=NULL,gradient.range.quantile=0.9
     }
     x[x<zlim[1]] <- zlim[1]; x[x>zlim[2]] <- zlim[2];
     x <- (x-zlim[1])/(zlim[2]-zlim[1])
-    
+
   }
-  
+
   gp <- gradientPalette[x*(length(gradientPalette)-1)+1]
   if(!is.null(names(x))) { names(gp) <- names(x) }
   gp
@@ -1749,15 +1749,15 @@ t.get.projected.cell <- function(em,deltae,delta=1,target.mult=1e3,model.mult=1e
 t.get.projected.cell2 <- function(em,cellSize,deltae,mult=1e3,delta=1) {
   rz <- matrix(0,nrow=nrow(em),ncol=ncol(em)); colnames(rz) <- colnames(em); rownames(rz) <- rownames(em)
   gn <- intersect(rownames(deltae),rownames(rz))
-  rz[match(gn,rownames(rz)),colnames(deltae)] <- deltae[gn,]; 
+  rz[match(gn,rownames(rz)),colnames(deltae)] <- deltae[gn,];
   # translate fpm delta into the number of molecules based on the current cell size
   rz <- t(t(rz)*cellSize)
   emm <- t(t(em)*cellSize)
-  emn <- emm + rz*delta; 
+  emn <- emm + rz*delta;
   emn[emn<0] <- 0;
   newCellSize <- (cellSize+Matrix::colSums(emn-emm)/mult)
   emn <- t(t(emn)/newCellSize)
-  
+
   #emn <- t(t(emn)/Matrix::colSums(emn)*Matrix::colSums(em))
   emn
 }
@@ -1813,7 +1813,7 @@ t.get.projected.delta2 <- function(em,nm,nm.size,gamma,offset=rep(0,length(gamma
   d <- em*egt + (1-egt)*t(t(y)/nm.size)/gamma  - em;
   d1 <- em*egt + (1-egt)*t(t(y1)/nm.size)/gamma  - em;
   d2 <- em*egt + (1-egt)*t(t(y2)/nm.size)/gamma  - em;
-  
+
   cd <- d;
   zi <- abs(cd)>abs(d1); cd[zi] <- d1[zi]
   zi <- abs(cd)>abs(d2); cd[zi] <- d2[zi]
@@ -1822,7 +1822,7 @@ t.get.projected.delta2 <- function(em,nm,nm.size,gamma,offset=rep(0,length(gamma
 }
 
 
-# estimate projected delta given log2 fold observed/expected nascent ratio 
+# estimate projected delta given log2 fold observed/expected nascent ratio
 # em - normalized expression matrix
 # nm - normalized nascent matrix
 # gamma - inferred degradation coefficients
@@ -1845,14 +1845,14 @@ points.within <- function(x,fs,fe,return.list=F,return.unique=F,sorted=F,return.
     ox <- rank(x,ties="first");
     x <- sort(x);
   }
-  
+
   se <- c(fs,fe);
   fi <- seq(1:length(fs));
   fi <- c(fi,-1*fi);
-  
+
   fi <- fi[order(se)];
   se <- sort(se);
-  
+
   storage.mode(x) <- storage.mode(fi) <- storage.mode(se) <- "integer";
   if(return.unique) { iu <- 1; } else { iu <- 0; }
   if(return.list) { il <- 1; } else { il <- 0; }

--- a/R/momentum_routines.R
+++ b/R/momentum_routines.R
@@ -557,12 +557,13 @@ filter.genes.by.cluster.expression <- function(emat,clusters,min.max.cluster.ave
   vi <- cl.emax>min.max.cluster.average;
 
   if (do.preview){
+    print(summary(quantile(cl.emax)))
     plot(density(cl.emax), xlab='Max Cluster-Avg', main='')
     abline(v=quantile(cl.emax), col='blue', lty='dashed')
     abline(v=min.max.cluster.average, col='maroon', lty='dashed')
     axis(side=3, at=quantile(cl.emax), labels=round(quantile(cl.emax), 2),
          col.ticks='blue')
-    message(paste0(length(which(vi)), '/', length(cl.emax), ' genes are selected.'))
+    print(paste0(length(which(vi)), '/', length(cl.emax), ' genes are selected.'))
   }
 
   emat[vi,]

--- a/R/momentum_routines.R
+++ b/R/momentum_routines.R
@@ -550,13 +550,24 @@ global.velcoity.estimates <- function(emat,nmat,vel,base.df,deltaT=1,smat=NULL,k
 ##' @param min.max.cluster.average required minimum average expression count (no normalization is perfomed)
 ##' @return filtered emat matrix
 ##' @export
-filter.genes.by.cluster.expression <- function(emat,clusters,min.max.cluster.average=0.1) {
+filter.genes.by.cluster.expression <- function(emat,clusters,min.max.cluster.average=0.1,do.preview=FALSE) {
   if(!any(colnames(emat) %in% names(clusters))) stop("provided clusters do not cover any of the emat cells!")
   vc <- intersect(colnames(emat),names(clusters))
   cl.emax <- apply(do.call(cbind,tapply(vc,as.factor(clusters[vc]),function(ii) Matrix::rowMeans(emat[,ii]))),1,max)
   vi <- cl.emax>min.max.cluster.average;
+
+  if (do.preview){
+    plot(density(cl.emax), xlab='Max Cluster-Avg', main='')
+    abline(v=quantile(cl.emax), col='blue', lty='dashed')
+    abline(v=min.max.cluster.average, col='maroon', lty='dashed')
+    axis(side=3, at=quantile(cl.emax), labels=round(quantile(cl.emax), 2),
+         col.ticks='blue')
+    message(paste0(length(which(vi)), '/', length(cl.emax), ' genes are selected.'))
+  }
+
   emat[vi,]
 }
+
 
 ##' PCA-based visualization of the velocities
 ##'

--- a/src/points_within.cpp
+++ b/src/points_within.cpp
@@ -21,14 +21,14 @@ SEXP points_within2(SEXP x_R,SEXP se_R,SEXP fi_R,SEXP return_list_R,SEXP return_
   int* se=INTEGER(se_R);
   int* fi=INTEGER(fi_R);
   int nf=LENGTH(se_R);
-            
+
   int return_list=*(INTEGER(return_list_R));
   int return_unique=*(INTEGER(return_unique_R));
   int return_point_counts=*(INTEGER(return_point_counts_R));
 
   set<int> fset;
-            
-            
+
+
   SEXP nv; int *i_nv;
   int np=0;
   if(return_point_counts) {
@@ -41,7 +41,7 @@ SEXP points_within2(SEXP x_R,SEXP se_R,SEXP fi_R,SEXP return_list_R,SEXP return_
     PROTECT(nv=allocVector(INTSXP,nx));  np++;
     i_nv=INTEGER(nv);
   }
-            
+
   int j=0;
   for(int i=0;i<nx;i++) {
     // advance j
@@ -49,7 +49,7 @@ SEXP points_within2(SEXP x_R,SEXP se_R,SEXP fi_R,SEXP return_list_R,SEXP return_
       int frag=fi[j];
       if(frag>0) { // insert
 	fset.insert(frag);
-            
+
       } else { // remove
 	fset.erase(-frag);
 
@@ -85,7 +85,7 @@ SEXP points_within2(SEXP x_R,SEXP se_R,SEXP fi_R,SEXP return_list_R,SEXP return_
       }
     }
   }
-            
+
   UNPROTECT(np);
   return nv;
 }

--- a/src/routines.cpp
+++ b/src/routines.cpp
@@ -17,14 +17,14 @@ arma::sp_mat  balanced_knn(const arma::mat& d,int k,int maxl,bool returnDistance
     dsi.col(i)=si;
     l.elem(si.subvec(0,k-1))+=1;
   }
-  
+
   arma::uvec lsi=sort_index(l,"descend"); // greedy order of column considerations
   l.zeros(); // reset so that l can be used to keep track of reciprocal counts in the kNN being constucted
   // greedy knn (construct row index vector)
   arma::uvec rowind(k*d.n_cols);
   arma::vec vals(k*d.n_cols,arma::fill::zeros); // values
   vals+=1.0; // default to ones
-            
+
   // run regular knn, record number of reciprocal neighbors
   for(int i=0;i<d.n_cols;i++) {
     int el=lsi[i]; // element for which the neighbors are being found
@@ -39,24 +39,24 @@ arma::sp_mat  balanced_knn(const arma::mat& d,int k,int maxl,bool returnDistance
       rowind[el*k+p]=m; l[m]++; p++; // record neighbor
       if(returnDistanceValues) { vals[el*k+p]=d(m,el); }
     }
-    if(j==dsi.n_rows && p<k) { 
-      rowind[el*k+p]=el; p++; // fill in last element(s) with self-identity if there were not enough spare elements 
+    if(j==dsi.n_rows && p<k) {
+      rowind[el*k+p]=el; p++; // fill in last element(s) with self-identity if there were not enough spare elements
       while(p<k) {
-	std::stringstream es; 
+	std::stringstream es;
 	es<<"unable to find unfilled neighbors for i="<<i<<" el="<<el<<" p="<<p;
-	Rf_warning(es.str().c_str()); 
+	Rf_warning(es.str().c_str());
 	rowind[el*k+p]=el; p++;
       }
     }
   }
-            
+
 
   // construct a column pointer index - every coulmn has only k entries, so its easy
 
   arma::uvec colptr(d.n_cols+1);
   int cc=0;
   for(int i=0;i<colptr.n_elem;i++) { colptr[i]=cc; cc+=k; }
-  // make return matrix  
+  // make return matrix
   arma::sp_mat knn(rowind,colptr,vals,d.n_rows,d.n_cols); // kNN matrix
   return(knn);
 }
@@ -77,7 +77,7 @@ arma::mat  colDeltaCor(const arma::mat& e, const arma::mat& d, int nthreads=1) {
     arma::mat t(e); t.each_col() -= e.col(i);
     rm.col(i)=cor(t,d.col(i));
   }
-      
+
   return(rm);
 }
 
@@ -90,7 +90,7 @@ arma::mat  colDeltaCorSqrt(const arma::mat& e, const arma::mat& d, int nthreads=
     t=sqrt(abs(t)) % sign(t);
     rm.col(i)=cor(t,d.col(i));
   }
-      
+
   return(rm);
 }
 
@@ -103,7 +103,7 @@ arma::mat  colDeltaCorLog10(const arma::mat& e, const arma::mat& d, double pseud
     t=log10(abs(t)+pseudocount) % sign(t);
     rm.col(i)=cor(t,d.col(i));
   }
-      
+
   return(rm);
 }
 
@@ -112,7 +112,7 @@ arma::mat  colDeltaCorLog10(const arma::mat& e, const arma::mat& d, double pseud
 // [[Rcpp::export]]
 arma::mat  colEuclid(const arma::mat& e, const arma::mat& p, int nthreads=1) {
   arma::mat rm(e.n_cols,e.n_cols);
-  
+
 #pragma omp parallel for shared(rm) num_threads(nthreads)
   for(int i=0;i<e.n_cols;i++) {
     arma::mat t(e); t.each_col() -= p.col(i);
@@ -131,7 +131,7 @@ arma::mat  embArrows(const arma::mat& emb, const arma::mat& tp, double arrowScal
 
   arma::mat dm(emb.n_cols,emb.n_rows);
   arma::mat tpb(ceil(tp)); // binarized version to give equal weights to each cell in the neighborhood
-  tpb.each_row() /= sum(tpb,0); // normalize 
+  tpb.each_row() /= sum(tpb,0); // normalize
   arma::colvec zv(emb.n_cols,arma::fill::zeros);
   arma::mat temb=trans(emb);
 #pragma omp parallel for shared(dm) num_threads(nthreads)


### PR DESCRIPTION
**Motivation**

The `min.max.cluster.average` parameter in `filter.genes.by.cluster.expression` does not have a suggested value. The users do not have a clear sense of how to choose a good threshold to select genes.

**Changes**

- Add a `do.preview` parameter (default: FALSE) for `filter.genes.by.cluster.expression` without making changes to the original functionality. See <https://github.com/velocyto-team/velocyto.R/pull/11/files#diff-471f4ee876c6283776976a3ed521c0b1R553>
- All trailing spaces are removed without violating the entire structure. (This was an accident actually due to my sublime text settings)

**Use**

Use the data from the official [tutorial](http://pklab.med.harvard.edu/velocyto/notebooks/R/chromaffin.nb.html)
```
> pdf('./test.pdf', 10, 7)
> emat <- filter.genes.by.cluster.expression(dat$emat,cell.colors,min.max.cluster.average = 5, do.preview=T)
    Min.  1st Qu.   Median     Mean  3rd Qu.     Max.
   0.000    0.000    1.413   16.715   16.952 8954.595
[1] "10130/24414 genes are selected."
> dev.off()
```
![test](https://user-images.githubusercontent.com/1233372/35224569-676609b0-ff53-11e7-9adc-aa4147ad81d3.png)

