### PR TITLE
Fixes embedding variable references

### DIFF
--- a/R/momentum_routines.R
+++ b/R/momentum_routines.R
@@ -198,8 +198,8 @@ gene.relative.velocity.estimates <- function(emat,nmat,deltaT=1,smat=NULL,steady
       # show embedding heatmaps
       cc <- intersect(rownames(cell.emb),colnames(conv.emat.norm));
       if(do.par) { par(mfrow=c(1,4), mar = c(2.5,2.5,2.5,0.5), mgp = c(1.5,0.65,0), cex = 0.85); }
-      plot(emb[cc,],pch=21,col=ac(1,alpha=0.2),bg=val2col(conv.emat.norm[gn,cc],gradientPalette=expression.gradient),cex=0.8,xlab='',ylab='',main=paste(gn,'s'),axes=F); box();
-      plot(emb[cc,],pch=21,col=ac(1,alpha=0.2),bg=val2col(conv.nmat.norm[gn,cc],gradientPalette=expression.gradient),cex=0.8,xlab='',ylab='',main=paste(gn,'u'),axes=F); box();
+      plot(cell.emb[cc,],pch=21,col=ac(1,alpha=0.2),bg=val2col(conv.emat.norm[gn,cc],gradientPalette=expression.gradient),cex=0.8,xlab='',ylab='',main=paste(gn,'s'),axes=F); box();
+      plot(cell.emb[cc,],pch=21,col=ac(1,alpha=0.2),bg=val2col(conv.nmat.norm[gn,cc],gradientPalette=expression.gradient),cex=0.8,xlab='',ylab='',main=paste(gn,'u'),axes=F); box();
     }
     do <- NULL;
     if(!is.null(smat)) { # use smat-based offsets
@@ -250,7 +250,7 @@ gene.relative.velocity.estimates <- function(emat,nmat,deltaT=1,smat=NULL,steady
     lines(df$e,predict(d,newdata=df),lty=2,col=2)
 
     if(!is.null(cell.emb)) {
-      plot(emb[cc,],pch=21,col=ac(1,alpha=0.2),bg=val2col(resid(d)[cc],gradientPalette=residual.gradient),cex=0.8,xlab='',ylab='',main=paste(gn,'resid'),axes=F); box();
+      plot(cell.emb[cc,],pch=21,col=ac(1,alpha=0.2),bg=val2col(resid(d)[cc],gradientPalette=residual.gradient),cex=0.8,xlab='',ylab='',main=paste(gn,'resid'),axes=F); box();
     }
     if(kGenes>1) { return(invisible(geneKNN)) } else { return(1) }
   }


### PR DESCRIPTION
In the [SmartSeq2 tutorial](http://pklab.med.harvard.edu/velocyto/notebooks/R/chromaffin.nb.html) the `gene.relative.velocity.estimates` example works because `emb` was globally defined earlier in `emb <- readRDS(url("http://pklab.med.harvard.edu/velocyto/chromaffin/embedding.rds"))`

However, if the embedding variable name is changed e.g. `emb_other_name <- readRDS(url("http://pklab.med.harvard.edu/velocyto/chromaffin/embedding.rds"))`, then the `gene.relative.velocity.estimates` block will fail because object `emb` is not found:
```R
calculating convolved matrices ... done
Error in plot(emb[cc, ], pch = 21, col = ac(1, alpha = 0.2), bg = val2col(conv.emat.norm[gn, : object 'emb' not found
Traceback:

1. gene.relative.velocity.estimates(emat, nmat, deltaT = 1, kCells = 5, 
 .     fit.quantile = 0.02, old.fit = rvel.qf, show.gene = "Chga", 
 .     cell.emb = emb_other_name, cell.colors = cell.colors)
2. plot(emb[cc, ], pch = 21, col = ac(1, alpha = 0.2), bg = val2col(conv.emat.norm[gn, 
 .     cc], gradientPalette = expression.gradient), cex = 0.8, xlab = "", 
 .     ylab = "", main = paste(gn, "s"), axes = F)
```

This commit corrects instances of `emb` to `cell.emb` 