### PR TITLE
add biocViews to automatically install Bioconductor deps

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -9,6 +9,7 @@ Description: Provides basic routines for estimation of gene-specific transcripti
 License: GPL-3
 Depends:
   Matrix
+biocViews:
 Imports: Rcpp (>= 0.12.13),
   MASS,
   mgcv,


### PR DESCRIPTION
Hi,

Thanks to the velocyto team for developing and maintaining this package! This is just a small PR that adds the `biocViews:` tag to the DESCRIPTION file to enable automatic download/install of the Bioconductor dependencies (in this case `pcaMethods`) when using devtools ( see https://github.com/r-lib/devtools/issues/700 for reference). 