### PR TITLE
add biocViews to DESCRIPTION

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -7,6 +7,7 @@ Author: Peter Kharchenko
 Maintainer: Peter Kharchenko <peter_kharchenko@hms.harvard.edu>
 Description: Provides basic routines for estimation of gene-specific transcriptional derivatives and visualization of the resulting velocity patterns.
 License: GPL-3
+biocViews:
 Depends:
   Matrix
 Imports: Rcpp (>= 0.12.13),


### PR DESCRIPTION
Bioconductor dependencies won't be automatically installed without additional annotations.

One way to indicate that some of the dependencies might come from Bioconductor is by
adding the string `biocViews:` to the DESCRIPTION file.

This code in [remotes] detects the string `biocViews:`:

https://github.com/r-lib/remotes/blob/c2013c25d905d73ca4326f2c5829165fea55f2ea/R/utils.R#L46-L48

[remotes]: https://github.com/r-lib/remotes

A second way to do it is to list each Bioconductor dependency twice. First, list it in `Depends:`, `Imports:`, or `Suggests:`. And then list it again a second time in `Remotes:`. This is described here:

https://devtools.r-lib.org/articles/dependencies.html#other-sources