### PR TITLE
macos-install

### DIFF
--- a/src/Makevars
+++ b/src/Makevars
@@ -1,4 +1,18 @@
-CXX_STD = CXX11
-PKG_CXXFLAGS= $(SHLIB_OPENMP_CXXFLAGS)
-PKG_CFLAGS=$(SHLIB_OPENMP_CFLAGS)
-PKG_LIBS=-lboost_filesystem -lboost_system   -lstdc++ $(LAPACK_LIBS) $(BLAS_LIBS)  $(SHLIB_OPENMP_CFLAGS) $(FLIBS) -L /usr/local/Cellar/boost/1.82.0_1/lib/
+XCBASE:=$(shell xcrun --show-sdk-path)
+LLVMBASE:=$(shell brew --prefix llvm)
+GCCBASE:=$(shell brew --prefix gcc)
+GETTEXT:=$(shell brew --prefix gettext)
+
+CC=$(LLVMBASE)/bin/clang -fopenmp
+CXX=$(LLVMBASE)/bin/clang++ -fopenmp
+CXX11=$(LLVMBASE)/bin/clang++ -fopenmp
+CXX14=$(LLVMBASE)/bin/clang++ -fopenmp
+CXX17=$(LLVMBASE)/bin/clang++ -fopenmp
+CXX1X=$(LLVMBASE)/bin/clang++ -fopenmp
+
+CPPFLAGS=-isystem "$(LLVMBASE)/include" -isysroot "$(XCBASE)"
+LDFLAGS=-L"$(LLVMBASE)/lib" -L"$(GETTEXT)/lib" --sysroot="$(XCBASE)"
+
+FC=$(GCCBASE)/bin/gfortran -fopenmp
+F77=$(GCCBASE)/bin/gfortran -fopenmp
+FLIBS=-L$(GCCBASE)/lib/gcc/9/ -lm

--- a/src/Makevars
+++ b/src/Makevars
@@ -1,4 +1,4 @@
 CXX_STD = CXX11
 PKG_CXXFLAGS= $(SHLIB_OPENMP_CXXFLAGS)
 PKG_CFLAGS=$(SHLIB_OPENMP_CFLAGS)
-PKG_LIBS=-lboost_filesystem -lboost_system   -lstdc++ $(LAPACK_LIBS) $(BLAS_LIBS)  $(SHLIB_OPENMP_CFLAGS) $(FLIBS)
+PKG_LIBS=-lboost_filesystem -lboost_system   -lstdc++ $(LAPACK_LIBS) $(BLAS_LIBS)  $(SHLIB_OPENMP_CFLAGS) $(FLIBS) -L /usr/local/Cellar/boost/1.82.0_1/lib/


### PR DESCRIPTION
Following several issues, MacOS users are currently unable to install Velocyto R directly from the GitHub repository. Making changes to the Makevars file following a similar [issue](https://github.com/kharchenkolab/conos/wiki/Installing-Conos-for-Mac-OS) worked for me and other users. This workaround requires each user to fork the repository, make the changes, and install from their own forked repo. Creating a new branch (for example macos-install) with these changes should allow MacOS users to install Velocyto without the need to do any additional steps:
`install_github("velocyto-team/velocyto.R", ref = "macos-install")`